### PR TITLE
Do not use variable for publishCmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,10 @@ FROM spotify/techdocs
 
 RUN apk --no-cache add bash npm
 
-RUN npm install -g @techdocs/cli
+RUN npm install -g @techdocs/cli --unsafe
 
 RUN pip install mkdocs-awesome-pages-plugin==2.5.0 mkdocs-nav-enhancements==0.9.1
 
-WORKDIR /github/workspace
+COPY main.sh /main.sh
 
-RUN chmod +x /main.sh
-
-ENTRYPOINT ["main.sh"]
+ENTRYPOINT ["/main.sh"]

--- a/action.yml
+++ b/action.yml
@@ -5,9 +5,9 @@ inputs:
     description: awsS3 | googleGcs | azureBlobStorage
     required: true
   credentials:
-    description: 
+    description:
       Credentials required to authenticate with your publisher through the techdocs-cli
-      For GCS, provide the JSON service account key file, as a base64-encoded string in GOOGLE_APPLICATION_CREDENTIALS 
+      For GCS, provide the JSON service account key file, as a base64-encoded string in GOOGLE_APPLICATION_CREDENTIALS
       For AWS, provide AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION, delimited by a space
       For Azure, provide AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET delimited by a space
     required: true
@@ -19,21 +19,29 @@ inputs:
     required: true
   azureAccountName:
     description: Azure account name, required if publisher is Azure
-  azureAccountKey: 
+  azureAccountKey:
     description: Azure Storage Account key. Use as an alternative authentication method to the credentials input
-  awsRoleArn: 
+  awsRoleArn:
     description: Optional AWS ARN of role to be assumed
-  awsEndpoint: 
+  awsEndpoint:
     description: Optional AWS endpoint to send requests to
 runs:
   using: docker
   image: Dockerfile
   args:
-  - '-a ${{ inputs.publisher }}'
-  - '-b ${{ inputs.credentials }}'
-  - '-c ${{ inputs.bucket }}'
-  - '-d ${{ inputs.entity }}'
-  - '-e ${{ inputs.azureAccountName }}'
-  - '-f ${{ inputs.azureAccountKey }}'
-  - '-g ${{ inputs.awsRoleArn }}'
-  - '-h ${{ inputs.awsEndpoint }}'
+  - '-a'
+  - ${{ inputs.publisher }}
+  - '-b'
+  - ${{ inputs.credentials }}
+  - '-c'
+  - ${{ inputs.bucket }}
+  - '-d'
+  - ${{ inputs.entity }}
+  - '-e'
+  - ${{ inputs.azureAccountName }}
+  - '-f'
+  - ${{ inputs.azureAccountKey }}
+  - '-g'
+  - ${{ inputs.awsRoleArn }}
+  - '-h'
+  - ${{ inputs.awsEndpoint }}


### PR DESCRIPTION
For whatever reason, the GOOGLE_APPLICATION_CREDENTIALS env var was not
available at the end of this file. Just having a separate invocation
in each branch _seems_ to fix it.