### PR TITLE
Quick fix: pin base docker image version to v1.2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM spotify/techdocs
+FROM spotify/techdocs:1.2.3
 
 RUN apk --no-cache add bash npm
 


### PR DESCRIPTION
The `spotify/techdocs` image got [updated yesterday](https://hub.docker.com/r/spotify/techdocs/tags) and among the changes, it updates the version of python it uses from 3.8 to 3.12 which breaks the version of `mkdocs` this action uses due to changes in Python's Collections API

This is a quick fix to just get the action working again ASAP by pinning the docker base image to the last working version.

Additional PRs will be made to update `mkdocs` and fix anything else that needs fixing so we can be up to date. We should also merge this action in with the rest of our shared actions at
https://github.com/gocardless/github-actions