### PR TITLE
Pin techdocs/cli version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,12 @@ FROM spotify/techdocs:v1.2.3
 
 RUN apk --no-cache add bash npm
 
-RUN npm install -g @techdocs/cli@^1.3.1
+RUN npm install -g @techdocs/cli@1.8.12
 
-RUN pip install mkdocs-awesome-pages-plugin==2.5.0 mkdocs-nav-enhancements==0.9.1 mkdocs-exclude==1.0.2 mkdocs-section-index==0.3.5
+RUN pip install --no-cache-dir mkdocs-awesome-pages-plugin==2.5.0 \
+    mkdocs-nav-enhancements==0.9.1 \
+    mkdocs-exclude==1.0.2 \
+    mkdocs-section-index==0.3.5
 
 COPY main.sh /main.sh
 


### PR DESCRIPTION
### Summary

This action is failing in all repos due to it not being able to install the latest version of the `techdocs/cli` npm package ([link to an example of a failing run](https://github.com/gocardless/airflow/actions/runs/10528532871/job/29174247057)).

In this PR, I've pinned the version to the latest one that successfully installs. 

### Testing

I've tested this change on [a branch in Airflow](https://github.com/gocardless/airflow/pull/10027) and verified that it fixes the issue ([link to passing run](https://github.com/gocardless/airflow/actions/runs/10559761478/job/29251825998?pr=10027)):

<img width="1804" alt="image" src="https://github.com/user-attachments/assets/0639e222-9c67-40c5-beff-f5235363b4d6">